### PR TITLE
[Feat] GameManager 및 범용 싱글톤 구현 + 씬 로딩 로직 통합

### DIFF
--- a/Assets/00_WorkSpace/DevIRU0413/Scripts.meta
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d4b81f7ccb5e724fb69cd491dd7a44f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/Interface.meta
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/Interface.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ffcc0e1b85769f49a4ca72a78a0cec6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/Interface/ILoadingUI.cs
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/Interface/ILoadingUI.cs
@@ -1,0 +1,6 @@
+public interface ILoadingUI
+{
+    void Show(string message);
+    void Hide();
+    void UpdateMessage(string message);
+}

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/Interface/ILoadingUI.cs.meta
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/Interface/ILoadingUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: be8695adc5366154a8884bbd6b53de2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/Util.meta
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/Util.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d6d78d9b9c1632341af1b3f34a581838
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/Util/YSJ_SimpleSingleton.cs
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/Util/YSJ_SimpleSingleton.cs
@@ -1,0 +1,59 @@
+﻿using UnityEngine;
+
+namespace Scripts.Util
+{
+    public abstract class YSJ_SimpleSingleton<T> : MonoBehaviour where T : MonoBehaviour
+    {
+        private static T _instance;
+        [SerializeField, HideInInspector] private bool _isDontDestroyOnLoad = true;
+
+        public static T Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = FindObjectOfType<T>();
+                    if (_instance == null)
+                    {
+#if UNITY_EDITOR
+                        Debug.LogWarning($"[SimpleSingleton] {typeof(T)} 인스턴스가 없어 에디터에서 자동 생성됨.");
+#endif
+                        GameObject go = new GameObject($"@SimpleSingleton_{typeof(T)}");
+                        _instance = go.AddComponent<T>();
+
+                        if ((_instance as YSJ_SimpleSingleton<T>)._isDontDestroyOnLoad)
+                            DontDestroyOnLoad(go);
+                    }
+                }
+                return _instance;
+            }
+        }
+
+        private void Awake() => Init();
+        private void OnDestroy() => Destroy();
+
+        protected virtual void Init()
+        {
+            {
+                if (_instance == null)
+                {
+                    _instance = this as T;
+                    if (_isDontDestroyOnLoad)
+                        DontDestroyOnLoad(gameObject);
+                }
+                else if (_instance != this)
+                {
+                    Destroy(gameObject);
+                }
+            }
+        }
+       protected virtual void Destroy()
+        {
+            if (_instance == this)
+            {
+                _instance = null;
+            }
+        }
+    }
+}

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/Util/YSJ_SimpleSingleton.cs.meta
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/Util/YSJ_SimpleSingleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0c34316a51c73f4da5536788ee384ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_GameManager.cs
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_GameManager.cs
@@ -1,0 +1,141 @@
+using Scripts.Util;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+// 나중에 자리 옮길 수 있으면 옮길 예정
+public enum GameState
+{
+    Init,
+    Loading,
+    Playing,
+    Paused,
+    GameOver
+}
+
+public class YSJ_GameManager : YSJ_SimpleSingleton<YSJ_GameManager>
+{
+
+    #region Public Field
+    public ILoadingUI LoadingUI;
+
+    public GameState CurrentState { get; private set; }
+    public event Action<GameState> OnGameStateChanged;
+    #endregion
+
+    protected override void Init()
+    {
+        base.Init();
+        ChangeState(GameState.Init);
+        EventManager.Instance.OnHQDestroyed += HandleHQDestroyed;
+    }
+
+    protected override void Destroy()
+    {
+        base.Destroy();
+        if (EventManager.Instance != null)
+            EventManager.Instance.OnHQDestroyed -= HandleHQDestroyed;
+    }
+
+    #region Handle
+    // Handle
+    private void HandleHQDestroyed(int teamId)
+    {
+        BroadcastGameOver(teamId);
+    }
+
+    // State
+    public void ChangeState(GameState newState)
+    {
+        if (CurrentState == newState) return;
+
+        CurrentState = newState;
+        Debug.Log($"Game State Changed: {CurrentState}");
+        OnGameStateChanged?.Invoke(CurrentState);
+    }
+
+    private void BroadcastGameOver(int losingTeamId)
+    {
+        ChangeState(GameState.GameOver);
+        Debug.Log($"Game Over! 팀 {losingTeamId} 패배");
+    }
+
+
+    #region 씬 로딩
+    // 씬 매니저 이전 예상
+
+    public void LoadSceneWithPreActions(string sceneName, List<(string message, Func<IEnumerator> action)> preActions = null, string finalMessage = "씬 로딩 중...")
+    {
+        StartCoroutine(TransitionScene(sceneName, preActions, finalMessage));
+    }
+
+    private IEnumerator TransitionScene(string sceneName, List<(string message, Func<IEnumerator> action)> preActions = null, string finalMessage = "씬 로딩 중...")
+    {
+        ChangeState(GameState.Loading);
+        LoadingUI?.Show("초기화 중..."); // 나중에 따로 빼도 됨
+
+        // 전처리 액션 실행
+        if (preActions != null)
+        {
+            foreach (var (message, action) in preActions)
+            {
+                if (!string.IsNullOrEmpty(message))
+                    LoadingUI?.UpdateMessage(message);
+
+                if (action != null)
+                    yield return StartCoroutine(action());
+            }
+        }
+
+        LoadingUI?.UpdateMessage(finalMessage);
+
+        // 씬 로딩
+        AsyncOperation async = SceneManager.LoadSceneAsync(sceneName);
+        while (!async.isDone)
+        {
+            yield return null;
+        }
+
+        LoadingUI?.Hide(); // 나중에 따로 빼도 됨
+        ChangeState(GameState.Playing);
+    }
+
+    #endregion
+
+    #region 게임 제어
+
+    public void PauseGame()
+    {
+        Time.timeScale = 0f;
+        ChangeState(GameState.Paused);
+    }
+
+    public void ResumeGame()
+    {
+        Time.timeScale = 1f;
+        ChangeState(GameState.Playing);
+    }
+
+    public void QuitGame()
+    {
+        Application.Quit();
+    }
+
+    #endregion
+
+    #region 설정 저장/불러오기
+
+    // 사운드(개인 설정)
+    public void SetVolume(float volume)
+    {
+        PlayerPrefs.SetFloat("Volume", volume);
+    }
+    public float GetVolume()
+    {
+        return PlayerPrefs.GetFloat("Volume", 0.5f);
+    }
+
+    #endregion
+}

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_GameManager.cs
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_GameManager.cs
@@ -45,6 +45,7 @@ public class YSJ_GameManager : YSJ_SimpleSingleton<YSJ_GameManager>
     {
         BroadcastGameOver(teamId);
     }
+    #endregion
 
     // State
     public void ChangeState(GameState newState)

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_GameManager.cs.meta
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e99f51867441ad2468ba41635c49b26a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 개요
- 게임 상태를 관리하는 `YSJ_GameManager` 구현
- 범용 싱글톤 베이스 클래스 `YSJ_SimpleSingleton<T>` 추가
- 씬 로딩 전/중 처리와 로딩 UI 출력 로직 통합
- `ILoadingUI` 인터페이스 도입으로 로딩 UI와 GameManager의 결합도 분리
- `PlayerPrefs`를 통한 볼륨 설정 저장/불러오기 기능 포함

---

## 변경 사항

### `YSJ_SimpleSingleton<T>`
- 컴포넌트 기반 싱글톤 패턴 구현
- 중복 인스턴스 방지 및 `DontDestroyOnLoad` 지원
- 에디터 실행 시 인스턴스 자동 생성 디버깅 지원

### `YSJ_GameManager`
- `GameState` Enum 정의: `Init`, `Loading`, `Playing`, `Paused`, `GameOver`
- `OnHQDestroyed` 이벤트 구독 → HQ 파괴 시 게임 오버 상태로 전환
- `LoadSceneWithPreActions()` 메서드로 씬 로딩 전/후 처리 흐름 구현
  - 전처리 액션을 순차 실행
  - 메시지 출력용 `ILoadingUI` 인터페이스 호출 포함
- `PauseGame`, `ResumeGame`, `QuitGame` 기능 구현
- `SetVolume`, `GetVolume`으로 `PlayerPrefs` 사용한 설정 저장 구현

---

#### 씬 전환 흐름 

```text
Init
 └─▶ LoadSceneWithPreActions
       └─▶ GameState.Loading
              └─▶ 전처리 액션 실행 및 로딩 메시지 출력
                    └─▶ 씬 로딩 완료 → GameState.Playing