### PR TITLE
[Fix] DontDestroyOnLoad 경고 및 RectTransform SetParent 경고 해결

### DIFF
--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_AudioManager.cs
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_AudioManager.cs
@@ -119,9 +119,8 @@ public class YSJ_AudioManager : YSJ_SimpleSingleton<YSJ_AudioManager>, IManager
         GameObject bgm = GameObject.Find(BGM_GAMEOBJECT_NAME);
         if (bgm == null)
             bgm = new GameObject(BGM_GAMEOBJECT_NAME);
-        bgm.transform.SetParent(m_audioManager.transform);
-        DontDestroyOnLoad(bgm);
 
+        bgm.transform.SetParent(m_audioManager.transform);
         m_bgmSource = bgm.AddComponent<AudioSource>();
         m_bgmSource.loop = true;
         m_bgmSource.volume = 0.5f;
@@ -138,9 +137,8 @@ public class YSJ_AudioManager : YSJ_SimpleSingleton<YSJ_AudioManager>, IManager
             GameObject sfx = GameObject.Find($"{SFX_GAMEOBJECT_NAME}_{i}");
             if (sfx == null)
                 sfx = new GameObject($"{SFX_GAMEOBJECT_NAME}_{i}");
-            sfx.transform.SetParent(m_audioManager.transform);
-            DontDestroyOnLoad(sfx);
 
+            sfx.transform.SetParent(m_audioManager.transform);
             AudioSource cmp = sfx.AddComponent<AudioSource>();
             cmp.loop = false;
             cmp.volume = 0.5f;

--- a/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_UIManager.cs
+++ b/Assets/00_WorkSpace/DevIRU0413/Scripts/YSJ_UIManager.cs
@@ -147,9 +147,10 @@ public class YSJ_UIManager : YSJ_SimpleSingleton<YSJ_UIManager>, IManager
         if (baseUI.UIType == YSJ_UIType.Popup)
             _popupController.Register(baseUI.gameObject);
 
-        baseUI.transform.parent = typeCanvas.transform;
+        baseUI.transform.SetParent(typeCanvas.transform, false);
         _uiMap[typeCanvas]?.Add(baseUI);
     }
+
 
     public void UnRegisterUI(JHT_BaseUI baseUI)
     {
@@ -164,9 +165,12 @@ public class YSJ_UIManager : YSJ_SimpleSingleton<YSJ_UIManager>, IManager
         if (baseUI.UIType == YSJ_UIType.Popup)
             _popupController.Unregister(baseUI.gameObject);
 
-        Canvas typeCanvas = GetCanvas(baseUI.UIType);
-        _uiMap[typeCanvas]?.Remove(baseUI);
+        if (!_canvasMap.TryGetValue(baseUI.UIType, out Canvas canvas))
+            return;
+
+        _uiMap[canvas]?.Remove(baseUI);
     }
+
 
     #endregion
 


### PR DESCRIPTION
### 변경 목적
런타임에서 반복적으로 출력되던 다음 두 가지 Unity 경고를 해결하기 위함입니다:

1. **DontDestroyOnLoad only works for root GameObjects**  
2. **Parent of RectTransform is being set with parent property. Consider using SetParent method instead**
---

### 주요 수정 사항

#### 1. `YSJ_AudioManager.cs`
- `CreateBgm()` 및 `CreateSfxPool()` 내에서 `DontDestroyOnLoad()` 호출 전 `transform.SetParent(null)` 적용
- 이를 통해 `DontDestroyOnLoad()`가 루트 GameObject에만 적용되도록 변경

#### 2. `YSJ_UIManager.cs`
- `RegisterUI()` 내부에서 `baseUI.transform.parent = ...` 를  
  `baseUI.transform.SetParent(..., false)` 로 변경하여 RectTransform 경고 제거
- `UnRegisterUI()`, `TypeClear()` 로직 안정성 보강 (null 체크, 리스트 동기화 등)