### PR TITLE
[Feat] Hero Respawn Logic 

### DIFF
--- a/Assets/00_WorkSpace/NormalSeed/Resources/Hero1.prefab
+++ b/Assets/00_WorkSpace/NormalSeed/Resources/Hero1.prefab
@@ -179,7 +179,7 @@ CapsuleCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
@@ -203,6 +203,7 @@ MonoBehaviour:
   view: {fileID: 0}
   mov: {fileID: 0}
   agent: {fileID: 0}
+  pv: {fileID: 0}
   heroType: 0
 --- !u!114 &5044435142328856903
 MonoBehaviour:

--- a/Assets/00_WorkSpace/NormalSeed/Scenes/MovementTest.unity
+++ b/Assets/00_WorkSpace/NormalSeed/Scenes/MovementTest.unity
@@ -1134,16 +1134,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5e7246983be56fe42842a970ae67d947, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prefabList:
-  - {fileID: 7666981763745117534, guid: cf0d57f0443f58343a7e7a72db1dee6c, type: 3}
-  - {fileID: 8626492250346720606, guid: 9172d86a66e3a664a9a1206699128008, type: 3}
-  - {fileID: 628576685217893846, guid: a3341e269ebc86a45abfbb0bc7966e8c, type: 3}
-  - {fileID: 4722950658263631852, guid: f130bc157017de941963635e2847e481, type: 3}
-  - {fileID: 2911596285320111480, guid: ea6cf804abe633f48a04e448b988368a, type: 3}
-  - {fileID: 3497919971631958939, guid: 41a4999ee48e19f4991739a12da75397, type: 3}
-  - {fileID: 3421545960365940984, guid: deb75b1a4a99af44a8ec1187a8f69cc5, type: 3}
-  - {fileID: 6909216629791466805, guid: cd45a13a55ce09c4c9a97e6916a9fbc6, type: 3}
-  - {fileID: 417341040573441857, guid: b573bf6298a1e344a9813999eb874fc9, type: 3}
+  prefabList: []
   _spwanPoint: []
   spawnInterval: 120
   groundObject: {fileID: 711083070}
@@ -1382,6 +1373,14 @@ PrefabInstance:
       propertyPath: inventoryView
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 1200246231334585774, guid: 2b5b3a4cdf1ddd347bda1fca6e1805b2, type: 3}
+      propertyPath: redSpawnPoint
+      value: 
+      objectReference: {fileID: 1861281577}
+    - target: {fileID: 1200246231334585774, guid: 2b5b3a4cdf1ddd347bda1fca6e1805b2, type: 3}
+      propertyPath: blueSpawnPoint
+      value: 
+      objectReference: {fileID: 1369468646}
     - target: {fileID: 1835633107611287557, guid: 2b5b3a4cdf1ddd347bda1fca6e1805b2, type: 3}
       propertyPath: m_Name
       value: GameManager

--- a/Assets/00_WorkSpace/NormalSeed/Scripts/Hero/HeroController.cs
+++ b/Assets/00_WorkSpace/NormalSeed/Scripts/Hero/HeroController.cs
@@ -90,8 +90,11 @@ public class HeroController : MonoBehaviour, IDamageable
         // Test용 코드들
         if (Input.GetKeyDown(KeyCode.Alpha1))
         {
-            model.CurHP.Value -= 10;
-            Debug.Log("현재 HP : " + model.CurHP.Value);
+            if (pv.IsMine)
+            {
+                pv.RPC("TakeDamage", RpcTarget.All, 100, default);
+                Debug.Log("현재 HP : " + model.CurHP.Value);
+            }
         }
         if (Input.GetKeyDown(KeyCode.Alpha2))
         {
@@ -254,5 +257,20 @@ public class HeroController : MonoBehaviour, IDamageable
     {
         model.CurHP.Value -= amount;
         Debug.Log($"{amount}의 데미지를 입음. 현재 HP : {model.CurHP.Value}");
+
+        if (model.CurHP.Value <= 0)
+        {
+            Dead();
+        }
+    }
+
+    public void Dead()
+    {
+        gameObject.SetActive(false);
+
+        if (pv.IsMine)
+        {
+            LGH_TestGameManager.Instance.RequestRespawn(this);
+        }
     }
 }

--- a/Assets/00_WorkSpace/NormalSeed/Scripts/Hero/HeroController.cs
+++ b/Assets/00_WorkSpace/NormalSeed/Scripts/Hero/HeroController.cs
@@ -260,10 +260,14 @@ public class HeroController : MonoBehaviour, IDamageable
 
         if (model.CurHP.Value <= 0)
         {
-            Dead();
+            if (pv.IsMine)
+            {
+                pv.RPC("Dead", RpcTarget.All);
+            }
         }
     }
 
+    [PunRPC]
     public void Dead()
     {
         gameObject.SetActive(false);
@@ -272,5 +276,15 @@ public class HeroController : MonoBehaviour, IDamageable
         {
             LGH_TestGameManager.Instance.RequestRespawn(this);
         }
+    }
+
+    [PunRPC]
+    public void RPC_Respawn(Vector3 spawnPos, float hp)
+    {
+        transform.position = spawnPos;
+        gameObject.SetActive(true);
+        model.CurHP.Value = hp;
+
+        Debug.Log($"리스폰 완료. 위치: {spawnPos}, HP: {hp}");
     }
 }

--- a/Assets/00_WorkSpace/NormalSeed/Scripts/Hero/HeroMovement.cs
+++ b/Assets/00_WorkSpace/NormalSeed/Scripts/Hero/HeroMovement.cs
@@ -154,11 +154,11 @@ public class HeroMovement : MonoBehaviour
         // 멈춤 동기화를 위해 RPC 실행
         pv.RPC(nameof(RPC_StopAndFace), RpcTarget.All, target.position);
         
-        // 타겟이 갖고 있는 HeroControlelr 안의 TakeDamage RPC 실행
+        // 타겟이 갖고 있는 TakeDamage RPC 실행
         PhotonView targetPv = target.gameObject.GetComponent<PhotonView>();
         if (targetPv != null)
         {
-            targetPv.RPC("TakeDamage", RpcTarget.All, damage, default); // TODO 데미지 줄 때 내가 줬다고 전달해줘야 함
+            targetPv.RPC("TakeDamage", RpcTarget.All, damage, this.gameObject); // TODO 데미지 줄 때 내가 줬다고 전달해줘야 함
         }
         Debug.Log("Hero1 기본 공격");
     }

--- a/Assets/00_WorkSpace/NormalSeed/Scripts/Skills/Hero1/Hero1SkillSet.cs
+++ b/Assets/00_WorkSpace/NormalSeed/Scripts/Skills/Hero1/Hero1SkillSet.cs
@@ -59,7 +59,7 @@ public class Hero1SkillSet : SkillSet
                 if (angle <= 30)
                 {
                     // 일단 데미지 계산식 없이 깡 스킬 데미지 부여
-                    view.RPC(nameof(HeroController.TakeDamage), RpcTarget.All, skill_Q.curDamage, default);
+                    view.RPC("TakeDamage", RpcTarget.All, skill_Q.curDamage, hero.gameObject);
                 }
             }
             Debug.Log("BladeWind");
@@ -133,6 +133,7 @@ public class Hero1SkillSet : SkillSet
                 // 먼저 데미지를 줄 수 있는 충돌인지 체크
                 if (damagable != null && view != null && !view.IsMine)
                 {
+                    // 팀 체크
                     object targetTeam, myTeam;
                     if (view.Owner.CustomProperties.TryGetValue("Team", out targetTeam) &&
                         PhotonNetwork.LocalPlayer.CustomProperties.TryGetValue("Team", out myTeam))
@@ -140,7 +141,8 @@ public class Hero1SkillSet : SkillSet
                         if (targetTeam == myTeam) continue;
                     }
 
-                    view.RPC(nameof(HeroController.TakeDamage), RpcTarget.All, skill_E.curDamage, default);
+                    // 영웅과 미니언 모두에게 데미지를 줄 수 있어야 함
+                    view.RPC("TakeDamage", RpcTarget.All, skill_E.curDamage, hero.gameObject);
                     Debug.Log("Bash Hit");
                 }
 

--- a/Assets/00_WorkSpace/NormalSeed/Scripts/Test/LGH_TestGameManager.cs
+++ b/Assets/00_WorkSpace/NormalSeed/Scripts/Test/LGH_TestGameManager.cs
@@ -21,6 +21,12 @@ public class LGH_TestGameManager : MonoBehaviourPunCallbacks, IManager
     [SerializeField] private InventoryHUDView inventoryView;
     InventoryHUDPresenter inventoryHUDPresenter;
 
+    [Header("팀별 리스폰 포인트")]
+    [SerializeField] private Transform redSpawnPoint;
+    [SerializeField] private Transform blueSpawnPoint;
+
+    private float respawnDelay = 20f;
+
     private void Awake()
     {
         // 이미 인스턴스가 존재하면 중복 제거
@@ -145,4 +151,47 @@ public class LGH_TestGameManager : MonoBehaviourPunCallbacks, IManager
     }
 
     public GameObject GetGameObject() => this.gameObject;
+
+    // 영웅 리스폰 로직
+    public void RequestRespawn(HeroController hero)
+    {
+        StartCoroutine(RespawnRoutine(hero));
+    }
+
+    private IEnumerator RespawnRoutine(HeroController hero)
+    {
+        Debug.Log("리스폰 대기중");
+        yield return new WaitForSeconds(respawnDelay);
+
+        // 팀 정보 가져옴
+        object teamObj;
+        PhotonNetwork.LocalPlayer.CustomProperties.TryGetValue("Team", out teamObj);
+        string team = teamObj?.ToString();
+
+        // 팀별 리스폰 위치 선택
+        Transform spawnPoint = GetSpawnPointByTeam(team);
+
+        // 위치 재설정 및 활성화
+        hero.transform.position = spawnPoint.position;
+        hero.gameObject.SetActive(true);
+        hero.model.CurHP.Value = hero.model.MaxHP;
+        Debug.Log("리스폰 완료. 팀 : " + team);
+    }
+
+    private Transform GetSpawnPointByTeam(string team)
+    {
+        if (team == "0")
+        {
+            return redSpawnPoint;
+        }
+
+        if (team == "1")
+        {
+            return blueSpawnPoint;
+        }
+
+        // 팀 정보가 없을 경우 디버깅
+        Debug.LogWarning("팀 정보 없음.");
+        return redSpawnPoint;
+    }
 }

--- a/Assets/00_WorkSpace/NormalSeed/Scripts/Test/LGH_TestGameManager.cs
+++ b/Assets/00_WorkSpace/NormalSeed/Scripts/Test/LGH_TestGameManager.cs
@@ -25,7 +25,7 @@ public class LGH_TestGameManager : MonoBehaviourPunCallbacks, IManager
     [SerializeField] private Transform redSpawnPoint;
     [SerializeField] private Transform blueSpawnPoint;
 
-    private float respawnDelay = 20f;
+    private float respawnDelay = 5f;
 
     private void Awake()
     {
@@ -172,10 +172,7 @@ public class LGH_TestGameManager : MonoBehaviourPunCallbacks, IManager
         Transform spawnPoint = GetSpawnPointByTeam(team);
 
         // 위치 재설정 및 활성화
-        hero.transform.position = spawnPoint.position;
-        hero.gameObject.SetActive(true);
-        hero.model.CurHP.Value = hero.model.MaxHP;
-        Debug.Log("리스폰 완료. 팀 : " + team);
+        hero.pv.RPC("RPC_Respawn", RpcTarget.All, spawnPoint.position, hero.model.MaxHP);
     }
 
     private Transform GetSpawnPointByTeam(string team)

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -64,6 +64,7 @@ MonoBehaviour:
   - UpdateHeroMP
   - Rpc_Initialize
   - Rpc_SetDestination
+  - ActivateAllPlayers
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1


### PR DESCRIPTION
영웅 플레이어의 현재 체력이 0 이하가 되었을 때 히어로 플레이어를 죽음 상태로 만들고 비활성화시킴
그 후 일정시간 후 자신의 팀의 리스폰 포인트에서 부활시키고 체력을 모두 회복시킴
-> 일련의 과정은 RPC를 이용해 네트워크상에서 동기화함